### PR TITLE
Fix federator BigInt mix crash and harden event log typing

### DIFF
--- a/federator/src/contracts/IAllowTokensV1.ts
+++ b/federator/src/contracts/IAllowTokensV1.ts
@@ -61,7 +61,7 @@ export class IAllowTokensV1 implements IAllowTokens {
     return confirmation * this.federatorInstance;
   }
 
-  async getSmallAmountConfirmations(): Promise<BigInt> {
+  async getSmallAmountConfirmations(): Promise<bigint> {
     try {
       return this.allowTokensContract.methods.smallAmountConfirmations().call();
     } catch (err) {
@@ -69,7 +69,7 @@ export class IAllowTokensV1 implements IAllowTokens {
     }
   }
 
-  async getMediumAmountConfirmations(): Promise<BigInt> {
+  async getMediumAmountConfirmations(): Promise<bigint> {
     try {
       return this.allowTokensContract.methods.mediumAmountConfirmations().call();
     } catch (err) {
@@ -77,7 +77,7 @@ export class IAllowTokensV1 implements IAllowTokens {
     }
   }
 
-  async getLargeAmountConfirmations(): Promise<BigInt> {
+  async getLargeAmountConfirmations(): Promise<bigint> {
     try {
       return this.allowTokensContract.methods.largeAmountConfirmations().call();
     } catch (err) {

--- a/federator/src/lib/Broker/HathorBroker.ts
+++ b/federator/src/lib/Broker/HathorBroker.ts
@@ -123,7 +123,7 @@ export class HathorBroker extends Broker {
     return [originalToken.tokenAddress, originalToken.originChainId];
   }
 
-  async isAmountAboveMinimumTransferAmount(isTokenEvmNative: boolean, _originalChainId: number, _tokenAddress: string, amount: BigInt): Promise<boolean> {
+  async isAmountAboveMinimumTransferAmount(isTokenEvmNative: boolean, _originalChainId: number, _tokenAddress: string, amount: bigint): Promise<boolean> {
 
     let evmTokenAddress = _tokenAddress;
 
@@ -136,7 +136,7 @@ export class HathorBroker extends Broker {
     return amount >= minimunTransferAmount;
   }
 
-  async getMinimumTransferAmount(_tokenAddress: string): Promise<BigInt> {
+  async getMinimumTransferAmount(_tokenAddress: string): Promise<bigint> {
     const limits = await this.allowTokensContract.getLimits({ tokenAddress: _tokenAddress });
     return limits.min;
   }
@@ -196,7 +196,7 @@ export class HathorBroker extends Broker {
 
   async voteOnEvm(
     receiverAddress: string,
-    amount: BigInt,
+    amount: bigint,
     tokenAddress: string,
     txId: string,
     ogSenderAddress: string,

--- a/federator/src/lib/FederatorHTR.ts
+++ b/federator/src/lib/FederatorHTR.ts
@@ -14,6 +14,7 @@ import { IFederation } from '../contracts/IFederation';
 import { LogWrapper } from './logWrapper';
 import { HathorService } from './HathorService';
 import {
+  CrossEventLog,
   GetLogsParams,
   ProcessLogsParams,
   ProcessToHathorLogParams,
@@ -23,6 +24,7 @@ import {
 import { HathorException } from '../types';
 import MetricRegister from '../utils/MetricRegister';
 import { IAllowTokensV1 } from '../contracts';
+import { EventLog } from 'web3-eth-contract';
 
 export default class FederatorHTR extends Federator {
   private readonly PATH_ORIGIN = 'fhtr';
@@ -157,10 +159,12 @@ export default class FederatorHTR extends Federator {
         throw new Error('Failed to obtain the logs');
       }
 
-      this.logger.info(`Found ${logs.length} logs`);
+      const crossLogs = logs.filter((log): log is EventLog => typeof log !== 'string') as CrossEventLog[];
+
+      this.logger.info(`Found ${crossLogs.length} logs`);
       await this._processLogs({
         ...getLogParams,
-        logs,
+        logs: crossLogs,
       });
       if (!getLogParams.mediumAndSmall) {
         this._saveProgress(
@@ -243,7 +247,7 @@ export default class FederatorHTR extends Federator {
       // At this point we're processing blocks newer than largeAmountConfirmations
       // and older than smallAmountConfirmations
       if (amountBN > largeAmountBN) {
-        const confirmations = processLogParams.currentBlock - blockNumber;
+        const confirmations = processLogParams.currentBlock - Number(blockNumber);
         const neededConfirmations = processLogParams.confirmations.largeAmountConfirmations;
         this.logger.debug(
           `[large amount] Tx: ${transactionHash} ${amount} originalTokenAddress:${tokenAddress} won't be proccessed yet ${confirmations} < ${neededConfirmations}`,
@@ -253,9 +257,9 @@ export default class FederatorHTR extends Federator {
 
       if (
         amountBN > mediumAmountBN &&
-        processLogParams.currentBlock - blockNumber < processLogParams.confirmations.mediumAmountConfirmations
+        processLogParams.currentBlock - Number(blockNumber) < processLogParams.confirmations.mediumAmountConfirmations
       ) {
-        const confirmations = processLogParams.currentBlock - blockNumber;
+        const confirmations = processLogParams.currentBlock - Number(blockNumber);
         const neededConfirmations = processLogParams.confirmations.mediumAmountConfirmations;
         this.logger.debug(
           `[medium amount] Tx: ${transactionHash} ${amount} originalTokenAddress:${tokenAddress} won't be proccessed yet ${confirmations} < ${neededConfirmations}`,
@@ -290,12 +294,17 @@ export default class FederatorHTR extends Federator {
         processTransactionParams.allowTokens as IAllowTokensV1,
       );
 
+      const transactionHash = processTransactionParams.log.transactionHash;
+      if (!transactionHash) {
+        throw new Error('Missing transactionHash on Cross event log');
+      }
+
       await hathorService.sendTokensToHathor(
         processTransactionParams.senderAddress,
         processTransactionParams.receiver,
         processTransactionParams.amount.toString(),
         processTransactionParams.tokenAddress,
-        processTransactionParams.log.transactionHash,
+        transactionHash,
       );
     } catch (error) {
       if (!(error instanceof HathorException)) throw error;

--- a/federator/src/lib/utils.ts
+++ b/federator/src/lib/utils.ts
@@ -226,7 +226,7 @@ export function clone(instance: any): any {
   return copy;
 }
 
-export function convertToEvmDecimals(originalQtd: number): BigInt {
+export function convertToEvmDecimals(originalQtd: number): bigint {
   try {
     const bnQtd = BigInt(originalQtd);
     const precision = BigInt(Math.pow(10, 16).toString());

--- a/federator/src/types/federator.ts
+++ b/federator/src/types/federator.ts
@@ -6,6 +6,7 @@ import { FederationFactory } from '../contracts/FederationFactory';
 import { AllowTokensFactory } from '../contracts/AllowTokensFactory';
 import { BridgeFactory } from '../contracts/BridgeFactory';
 import { IFederation } from '../contracts/IFederation';
+import { EventLog } from 'web3-eth-contract';
 
 export interface BaseLogsParams {
   sideChainId: number;
@@ -20,22 +21,37 @@ export interface BaseLogsParams {
   bridgeFactory: BridgeFactory;
 }
 
+export interface CrossEventReturnValues {
+  [key: string]: unknown;
+  _to: string;
+  _from: string;
+  _amount: bigint;
+  _tokenAddress: string;
+  _typeId: string;
+  _originChainId: bigint | number | string;
+  _destinationChainId: bigint | number | string;
+}
+
+export type CrossEventLog = EventLog & {
+  returnValues: CrossEventReturnValues;
+};
+
 export interface GetLogsParams extends BaseLogsParams {
   fromBlock: number;
   toBlock: number;
 }
 
 export interface ProcessLogsParams extends BaseLogsParams {
-  logs: any[];
+  logs: CrossEventLog[];
 }
 
 export interface ProcessToHathorLogParams extends BaseLogsParams {
-  log: any;
+  log: CrossEventLog;
   allowTokens: IAllowTokens;
 }
 
 export interface ProcessLogParams extends BaseLogsParams {
-  log: any;
+  log: CrossEventLog;
   sideFedContract: IFederation;
   allowTokens: IAllowTokens;
   federatorAddress: string;
@@ -46,7 +62,7 @@ export interface ProcessTransactionParams extends ProcessLogParams {
   tokenAddress: string;
   senderAddress: string;
   receiver: string;
-  amount: BigInt;
+  amount: bigint;
   typeId: string;
   transactionId: string;
   originChainId: number;
@@ -57,7 +73,7 @@ export interface ProcessToHathorTransactionParams extends ProcessToHathorLogPara
   tokenAddress: string;
   senderAddress: string;
   receiver: string;
-  amount: BigInt;
+  amount: bigint;
   typeId: string;
   originChainId: number;
   destinationChainId: number;
@@ -73,7 +89,7 @@ export interface VoteHathorTransactionParams {
   tokenAddress: string;
   senderAddress: string;
   receiver: string;
-  amount: BigInt;
+  amount: bigint;
   transactionId: string;
   originChainId: number;
   destinationChainId: number;
@@ -92,7 +108,7 @@ export interface TransactionIdParams {
   originalTokenAddress: string;
   sender: string;
   receiver: string;
-  amount: BigInt;
+  amount: bigint;
   blockHash: string;
   transactionHash: string;
   logIndex: number;


### PR DESCRIPTION
## Problem

The federator was crashing while processing `Cross` events with:

`TypeError: Cannot mix BigInt and other types, use explicit conversions`

Root cause:
- `currentBlock` was handled as `number`
- `blockNumber` from Web3 v4 event logs can be `bigint`
- We had arithmetic/comparisons mixing both types in `FederatorHTR`

This caused runtime failures in the event processing loop.

## What This PR Changes

### Runtime fix
- Normalizes arithmetic operands in `FederatorHTR` by converting `blockNumber` before subtraction/comparison.
- This removes the `number` vs `bigint` runtime mix that triggered the crash.

### Typing hardening
- Migrates `BigInt` annotations to primitive `bigint` in the touched federator flow.
- Introduces a typed `CrossEventLog` shape based on `EventLog`, with typed `returnValues` for `Cross` fields.
- Replaces loose `any`-based log flow in the touched path with stricter types.
- Adds a guard for optional `transactionHash` before passing it downstream.

## Why typing changes were included

The production issue happened because loose typing (`any`) allowed incompatible numeric types to pass unnoticed until runtime.

By making the event log path more explicit, we reduce the chance of similar mistakes and make IDE/TS diagnostics more useful around `Cross` event processing.

## Important caveat

This repository does not currently run with full TypeScript strictness by default. That means:
- these type improvements increase safety in the touched code,
- but some benefits are still limited because non-strict compilation can miss broader nullability/unknown issues.

In short: this improves safety now, and strict mode adoption later would amplify the protection.
